### PR TITLE
Keep recent emoji state constants

### DIFF
--- a/lib/src/widgets/emoji_section.dart
+++ b/lib/src/widgets/emoji_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_emoji_mart/flutter_emoji_mart.dart';
+import 'package:flutter_emoji_mart/src/widgets/emoji_stream_builder.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
@@ -47,29 +48,23 @@ class EmojiSection extends StatelessWidget {
     Widget child;
     if (category.id == EmojiPickerConfiguration.recentCategoryId &&
         category.emojiIds.isEmpty) {
-      child = FutureBuilder<Category?>(
-        future: recentEmoji,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const SliverToBoxAdapter(
-              child: Center(child: CircularProgressIndicator()),
-            );
-          }
-          if (!snapshot.hasData || snapshot.data!.emojiIds.isEmpty) {
+      child = EmojiStreamBuilder(
+        categoryFuture: recentEmoji,
+        builder: (emojiIds) {
+          if (emojiIds.isEmpty) {
             return const SliverToBoxAdapter(
               child: SizedBox(height: 16),
             );
           }
-          final recentCategory = snapshot.data!;
           return SliverGrid.builder(
-            itemCount: recentCategory.emojiIds.length,
+            itemCount: emojiIds.length,
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: configuration.perLine,
               crossAxisSpacing: configuration.crossAxisSpacing,
               mainAxisSpacing: configuration.mainAxisSpacing,
             ),
             itemBuilder: (context, index) {
-              final emojiId = recentCategory.emojiIds[index];
+              final emojiId = emojiIds[index];
               final emoji = emojiData.getEmojiById(
                 emojiId,
                 skinTone: skinTone,

--- a/lib/src/widgets/emoji_stream_builder.dart
+++ b/lib/src/widgets/emoji_stream_builder.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_emoji_mart/src/data/emoji_data.dart';
+
+class EmojiStreamBuilder extends StatefulWidget {
+  const EmojiStreamBuilder({
+    super.key,
+    required this.categoryFuture,
+    required this.builder,
+  });
+
+  final Future<Category?>? categoryFuture;
+  final Widget Function(List<String> emojiIds) builder;
+
+  @override
+  State<EmojiStreamBuilder> createState() => _EmojiStreamBuilderState();
+}
+
+class _EmojiStreamBuilderState extends State<EmojiStreamBuilder> {
+  late final StreamController<List<String>> _streamController;
+
+  Future<void> _extractEmojiIdsFromCategory() async {
+    if (widget.categoryFuture == null) return;
+    final category = await widget.categoryFuture!;
+    if (category == null || category.emojiIds.isEmpty) return;
+    _streamController.add(List.unmodifiable(category.emojiIds));
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _streamController = StreamController.broadcast();
+    _extractEmojiIdsFromCategory();
+  }
+
+  @override
+  void didUpdateWidget(covariant EmojiStreamBuilder oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _extractEmojiIdsFromCategory();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _streamController.close();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder(
+      stream: _streamController.stream.distinct(),
+      builder: (context, snapshot) {
+        return widget.builder(snapshot.hasData ? snapshot.requireData : []);
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Issue
If the EmojiPicker widget is rebuilt constantly, the FutureBuilder is invoked everytime, making the state update from loading->data->loading->data and so on.
